### PR TITLE
feat:make group pool settings persistent

### DIFF
--- a/hoshino/modules/priconne/gacha/__init__.py
+++ b/hoshino/modules/priconne/gacha/__init__.py
@@ -7,6 +7,10 @@ from hoshino.util import silence, concat_pic, pic2b64, DailyNumberLimiter
 
 from .gacha import Gacha
 from ..chara import Chara
+from hoshino.log import logger
+
+import os
+import json
 
 sv = Service('gacha')
 jewel_limit = DailyNumberLimiter(6000)
@@ -16,34 +20,42 @@ GACHA_DISABLE_NOTICE = '本群转蛋功能已禁用\n如欲开启，请与维护
 JEWEL_EXCEED_NOTICE = f'您今天已经抽过{jewel_limit.max}钻了，欢迎明早5点后再来！'
 TENJO_EXCEED_NOTICE = f'您今天已经抽过{tenjo_limit.max}张天井券了，欢迎明早5点后再来！'
 SWITCH_POOL_TIP = 'β>发送"选择卡池"可切换'
-
+filename = os.path.join(os.path.dirname(__file__), 'group_pool_config.json')
 POOL = ('MIX', 'JP', 'TW', 'BL')
 DEFAULT_POOL = POOL[0]
-_group_pool = defaultdict(lambda: DEFAULT_POOL)
+try:
+    with open(filename, encoding='utf8') as f:
+        group_pool = json.load(f)
+except Exception as e:
+    group_pool = {}
+    logger.exception(e)
+_group_pool = defaultdict(lambda: DEFAULT_POOL, group_pool)
 
-gacha_10_aliases = ('十连', '十连！', '十连抽', '来个十连', '来发十连', '来次十连', '抽个十连', '抽发十连', '抽次十连', '十连扭蛋', '扭蛋十连',
+gacha_10_aliases = ('抽十连', '十连', '十连！', '十连抽', '来个十连', '来发十连', '来次十连', '抽个十连', '抽发十连', '抽次十连', '十连扭蛋', '扭蛋十连',
                     '10连', '10连！', '10连抽', '来个10连', '来发10连', '来次10连', '抽个10连', '抽发10连', '抽次10连', '10连扭蛋', '扭蛋10连',
                     '十連', '十連！', '十連抽', '來個十連', '來發十連', '來次十連', '抽個十連', '抽發十連', '抽次十連', '十連轉蛋', '轉蛋十連',
                     '10連', '10連！', '10連抽', '來個10連', '來發10連', '來次10連', '抽個10連', '抽發10連', '抽次10連', '10連轉蛋', '轉蛋10連')
 gacha_1_aliases = ('单抽', '单抽！', '来发单抽', '来个单抽', '来次单抽', '扭蛋单抽', '单抽扭蛋',
                    '單抽', '單抽！', '來發單抽', '來個單抽', '來次單抽', '轉蛋單抽', '單抽轉蛋')
-gacha_300_aliases = ('抽一井', '来一井', '来发井', '抽发井', '天井扭蛋', '扭蛋天井', '天井轉蛋', '轉蛋天井')
+gacha_300_aliases = ('抽一井', '来一井', '来发井', '抽发井',
+                     '天井扭蛋', '扭蛋天井', '天井轉蛋', '轉蛋天井')
 
 
-@sv.on_command('卡池资讯', deny_tip=GACHA_DISABLE_NOTICE, aliases=('查看卡池', '看看卡池', '康康卡池', '卡池資訊','看看up','看看UP'), only_to_me=False)
-async def gacha_info(session:CommandSession):
-    gid = session.ctx['group_id']
+@sv.on_command('卡池资讯', deny_tip=GACHA_DISABLE_NOTICE, aliases=('查看卡池', '看看卡池', '康康卡池', '卡池資訊', '看看up', '看看UP'), only_to_me=False)
+async def gacha_info(session: CommandSession):
+    gid = str(session.ctx['group_id'])
     gacha = Gacha(_group_pool[gid])
     up_chara = gacha.up
     if sv.bot.config.IS_CQPRO:
-        up_chara = map(lambda x: str(Chara.fromname(x).icon.cqcode) + x, up_chara)
+        up_chara = map(lambda x: str(
+            Chara.fromname(x).icon.cqcode) + x, up_chara)
     up_chara = '\n'.join(up_chara)
     await session.send(f"本期卡池主打的角色：\n{up_chara}\nUP角色合计={(gacha.up_prob/10):.1f}% 3★出率={(gacha.s3_prob)/10:.1f}%\n{SWITCH_POOL_TIP}")
 
 
 POOL_NAME_TIP = '请选择以下卡池\n> 选择卡池 jp\n> 选择卡池 tw\n> 选择卡池 bilibili\n> 选择卡池 mix'
 @sv.on_command('切换卡池', aliases=('选择卡池', '切換卡池', '選擇卡池'), only_to_me=False)
-async def set_pool(session:CommandSession):
+async def set_pool(session: CommandSession):
     if not sv.check_priv(session.ctx, required_priv=Priv.ADMIN):
         session.finish('只有群管理才能切换卡池', at_sender=True)
     name = util.normalize_str(session.current_arg_text)
@@ -61,8 +73,13 @@ async def set_pool(session:CommandSession):
         name = 'MIX'
     else:
         session.finish(f'未知服务器地区 {POOL_NAME_TIP}', at_sender=True)
-    gid = session.ctx['group_id']
+    gid = str(session.ctx['group_id'])
     _group_pool[gid] = name
+    try:
+        with open(filename, 'w', encoding='utf8') as f:
+            json.dump(_group_pool, f, indent=4)
+    except Exception as e:
+        logger.exception(e)
     await session.send(f'卡池已切换为{name}池', at_sender=True)
 
 
@@ -71,22 +88,24 @@ async def check_jewel_num(session):
     if not jewel_limit.check(uid):
         await session.finish(JEWEL_EXCEED_NOTICE, at_sender=True)
 
+
 async def check_tenjo_num(session):
     uid = session.ctx['user_id']
     if not tenjo_limit.check(uid):
         await session.finish(TENJO_EXCEED_NOTICE, at_sender=True)
 
 
-@sv.on_command('gacha_1', deny_tip=GACHA_DISABLE_NOTICE, aliases=gacha_1_aliases, only_to_me=True)
-async def gacha_1(session:CommandSession):
+@sv.on_command('gacha_1', deny_tip=GACHA_DISABLE_NOTICE, aliases=gacha_1_aliases, only_to_me=False)
+async def gacha_1(session: CommandSession):
 
     await check_jewel_num(session)
     uid = session.ctx['user_id']
     jewel_limit.increase(uid, 150)
 
-    gid = session.ctx['group_id']
+    gid = str(session.ctx['group_id'])
     gacha = Gacha(_group_pool[gid])
-    chara, hiishi = gacha.gacha_one(gacha.up_prob, gacha.s3_prob, gacha.s2_prob)
+    chara, hiishi = gacha.gacha_one(
+        gacha.up_prob, gacha.s3_prob, gacha.s2_prob)
     silence_time = hiishi * 60
 
     res = f'{chara.name} {"★"*chara.star}'
@@ -97,22 +116,22 @@ async def gacha_1(session:CommandSession):
     await session.send(f'素敵な仲間が増えますよ！\n{res}\n{SWITCH_POOL_TIP}', at_sender=True)
 
 
-@sv.on_command('gacha_10', deny_tip=GACHA_DISABLE_NOTICE, aliases=gacha_10_aliases, only_to_me=True)
-async def gacha_10(session:CommandSession):
+@sv.on_command('gacha_10', deny_tip=GACHA_DISABLE_NOTICE, aliases=gacha_10_aliases, only_to_me=False)
+async def gacha_10(session: CommandSession):
     SUPER_LUCKY_LINE = 170
 
     await check_jewel_num(session)
     uid = session.ctx['user_id']
     jewel_limit.increase(uid, 1500)
-    
-    gid=session.ctx['group_id']
+
+    gid = str(session.ctx['group_id'])
     gacha = Gacha(_group_pool[gid])
     result, hiishi = gacha.gacha_ten()
     silence_time = hiishi * 6 if hiishi < SUPER_LUCKY_LINE else hiishi * 60
 
     if sv.bot.config.IS_CQPRO:
-        res1 = Chara.gen_team_pic(result[ :5], star_slot_verbose=False)
-        res2 = Chara.gen_team_pic(result[5: ], star_slot_verbose=False)
+        res1 = Chara.gen_team_pic(result[:5], star_slot_verbose=False)
+        res2 = Chara.gen_team_pic(result[5:], star_slot_verbose=False)
         res = concat_pic([res1, res2])
         res = pic2b64(res)
         res = MessageSegment.image(res)
@@ -132,14 +151,14 @@ async def gacha_10(session:CommandSession):
     await silence(session.ctx, silence_time)
 
 
-@sv.on_command('gacha_300', deny_tip=GACHA_DISABLE_NOTICE, aliases=gacha_300_aliases, only_to_me=True)
-async def gacha_300(session:CommandSession):
+@sv.on_command('gacha_300', deny_tip=GACHA_DISABLE_NOTICE, aliases=gacha_300_aliases, only_to_me=False)
+async def gacha_300(session: CommandSession):
 
     await check_tenjo_num(session)
     uid = session.ctx['user_id']
     tenjo_limit.increase(uid)
 
-    gid=session.ctx['group_id']
+    gid = str(session.ctx['group_id'])
     gacha = Gacha(_group_pool[gid])
     result = gacha.gacha_tenjou()
     up = len(result['up'])
@@ -202,7 +221,7 @@ async def gacha_300(session:CommandSession):
 
 
 @sv.on_rex(r'^氪金$', normalize=False)
-async def kakin(bot:NoneBot, ctx, match):
+async def kakin(bot: NoneBot, ctx, match):
     if ctx['user_id'] not in bot.config.SUPERUSERS:
         return
     count = 0


### PR DESCRIPTION
Spare some time to learn how to use python-json, then I try to modify the gacha.py so that HoshinoBot can store _group_pool persistently at group_pool_config.json. 
Of cause, it works well at my server and hope you can have a try.
Thanks！

 