### PR TITLE
修复mikan可能的500错误

### DIFF
--- a/hoshino/modules/mikan/mikan.py
+++ b/hoshino/modules/mikan/mikan.py
@@ -23,7 +23,7 @@ class Mikan(object):
     def get_rss():
         res = []
         try:
-            resp = requests.get('https://mikanani.me/RSS/MyBangumi', params={'token': Mikan.get_token()}, timeout=1)
+            resp = requests.get('https://mikanani.me/RSS/MyBangumi', params='token='+ Mikan.get_token(), timeout=1)
             rss = etree.XML(resp.content)
         except Exception as e:
             sv.logger.error(f'[get_rss] Error: {e}')


### PR DESCRIPTION
token中带有百分号经过requests转码后，返回500