### PR TITLE
修复cqhttp for mirai在使用Hoshino过程中的权限问题

### DIFF
--- a/hoshino/priv.py
+++ b/hoshino/priv.py
@@ -63,6 +63,8 @@ def get_user_priv(ev: CQEvent):
                 return ADMIN
             elif role == 'owner':
                 return OWNER
+            elif role == 'administrator':
+            	return Privilege.ADMIN
         return NORMAL
     if ev['message_type'] == 'private':
         return PRIVATE

--- a/hoshino/priv.py
+++ b/hoshino/priv.py
@@ -61,10 +61,11 @@ def get_user_priv(ev: CQEvent):
                 return NORMAL
             elif role == 'admin':
                 return ADMIN
+            #for cqhttpmirai
+            elif role == 'administrator':
+            	return ADMIN
             elif role == 'owner':
                 return OWNER
-            elif role == 'administrator':
-            	return Privilege.ADMIN
         return NORMAL
     if ev['message_type'] == 'private':
         return PRIVATE
@@ -76,4 +77,3 @@ def check_priv(ev: CQEvent, require: int) -> bool:
         return bool(get_user_priv(ev) >= require)
     else:
         return False  # 不允许私聊
-

--- a/hoshino/priv.py
+++ b/hoshino/priv.py
@@ -76,3 +76,4 @@ def check_priv(ev: CQEvent, require: int) -> bool:
         return bool(get_user_priv(ev) >= require)
     else:
         return False  # 不允许私聊
+


### PR DESCRIPTION
来源：https://bbs.yobot.top/d/21 （地河佬nb）
使用CQHTTPMirai部署HoshinoBot时会遇到权限判断不对的bug，出了SUPERUSER外的所有用户权限均为1。
为了修复这个bug，你应该将[cqhttp for mirai](https://github.com/yyuueexxiinngg/cqhttp-mirai)更新到最新版本（要做到这一点，你应该对其进行编译而非直接下载最新release）

对于Hoshino V1版本的修复参见来源