### PR TITLE
一些小改动

### DIFF
--- a/hoshino/modules/groupmaster/chat.py
+++ b/hoshino/modules/groupmaster/chat.py
@@ -5,7 +5,7 @@ from nonebot import on_command
 
 from hoshino import R, Service, priv, util
 from hoshino.config import SUPERUSERS
-
+from hoshino.util import reply_msg
 # basic function for debug, not included in Service('chat')
 @on_command('zai?', aliases=('在?', '在？', '在吗', '在么？', '在嘛', '在嘛？'), only_to_me=True)
 async def say_hello(session):
@@ -34,7 +34,7 @@ async def chat_waifu(bot, ev):
     if not priv.check_priv(ev, priv.SUPERUSER):
         await bot.send(ev, R.img('laopo.jpg').cqcode)
     else:
-        await bot.send(ev, 'mua~')
+        await reply_msg(ev, 'mua~')
 
 
 @sv.on_fullmatch('老公', only_to_me=True)
@@ -54,13 +54,13 @@ async def seina(bot, ev):
 
 @sv.on_fullmatch(('我有个朋友说他好了', '我朋友说他好了', ))
 async def ddhaole(bot, ev):
-    await bot.send(ev, '那个朋友是不是你弟弟？')
+    await reply_msg(ev, '那个朋友是不是你弟弟？')
     await util.silence(ev, 30)
 
 
 @sv.on_fullmatch('我好了')
 async def nihaole(bot, ev):
-    await bot.send(ev, '不许好，憋回去！')
+    await reply_msg(ev, '不许好，憋回去！')
     await util.silence(ev, 30)
 
 

--- a/hoshino/modules/groupmaster/chat.py
+++ b/hoshino/modules/groupmaster/chat.py
@@ -1,15 +1,26 @@
+
 import random
 
 from nonebot import on_command
 
 from hoshino import R, Service, priv, util
-
+from hoshino.config import SUPERUSERS
 
 # basic function for debug, not included in Service('chat')
 @on_command('zai?', aliases=('在?', '在？', '在吗', '在么？', '在嘛', '在嘛？'), only_to_me=True)
 async def say_hello(session):
     await session.send('はい！私はいつも貴方の側にいますよ！')
 
+@on_command('echo', only_to_me=False)
+async def echo(session):
+    msg = session.current_arg.strip()
+    uid = session.event.user_id
+    if uid not in SUPERUSERS or msg == '':
+        return
+    msg = msg.replace('&amp;','&')
+    msg = msg.replace('&#91;','[')
+    msg = msg.replace('&#93;',']')
+    await session.finish(msg)
 
 sv = Service('chat', visible=False)
 

--- a/hoshino/modules/setu/setu.py
+++ b/hoshino/modules/setu/setu.py
@@ -27,7 +27,7 @@ setu_gener = setu_gener()
 def get_setu():
     return setu_gener.__next__()
 
-
+@sv.on_image('b3bbbd10e30b6c05ef35766efd4a550e')
 @sv.on_rex(r'不够[涩瑟色]|[涩瑟色]图|来一?[点份张].*[涩瑟色]|再来[点份张]|看过了|铜')
 async def setu(bot, ev):
     """随机叫一份涩图，对每个用户有冷却时间"""

--- a/hoshino/service.py
+++ b/hoshino/service.py
@@ -195,6 +195,17 @@ class Service:
         return deco
 
 
+    def on_image(self, image, only_to_me=False) -> Callable:
+        if isinstance(image, str):
+            image = (image, )
+        def deco(func) -> Callable:
+            sf = ServiceFunc(self, func, only_to_me)
+            for i in image:
+                trigger.image.add(i, sf)
+            return func
+        return deco
+
+
     def on_prefix(self, prefix, only_to_me=False) -> Callable:
         if isinstance(prefix, str):
             prefix = (prefix, )

--- a/hoshino/util/__init__.py
+++ b/hoshino/util/__init__.py
@@ -38,6 +38,19 @@ def load_config(inbuilt_file_var):
         return {}
 
 
+async def reply_msg(ev:CQEvent, message:str) -> str:
+    msgid = ev.message_id
+    replyCQ = f'[CQ:reply,id={msgid}]'
+    msg = replyCQ + message
+    bot = hoshino.get_bot()
+    try:
+        await bot.send(ev, msg)
+    except ActionFailed as e:
+        hoshino.logger.error(f'回复失败 retcode={e.retcode}')
+    except Exception as e:
+        hoshino.logger.exception(e)
+
+
 async def delete_msg(ev: CQEvent):
     try:
         await hoshino.get_bot().delete_msg(self_id=ev.self_id, message_id=ev.message_id)

--- a/hoshino/util/__init__.py
+++ b/hoshino/util/__init__.py
@@ -58,9 +58,13 @@ async def silence(ev: CQEvent, ban_time, skip_su=True):
         hoshino.logger.exception(e)
 
 
-def pic2b64(pic:Image) -> str:
+def pic2b64(pic:Image, jpeg=False) -> str:
     buf = BytesIO()
-    pic.save(buf, format='PNG')
+    if not jpeg:
+        pic.save(buf, format='PNG')
+    else:
+        pic = pic.convert('RGB')
+        pic.save(buf, format='JPEG')
     base64_str = base64.b64encode(buf.getvalue()).decode()
     return 'base64://' + base64_str
 


### PR DESCRIPTION
一些个人自用的修改：
1. 比葫芦画瓢加了个`ImageTrigger`，使用图片的文件名（实际就是32位哈希值吧应该）来触发函数，并同时为色图插件增加了这一个入口，群内发送“色图来”表情包即可触发，图片哈希值需要后台获取。
2. `chat.py`增加了个调试函数`echo()`，可以方便发送CQ码进行调试（仅限超级管理员）。
3. `pic2b64()`函数支持转换到JPEG，因为时候PNG体积过大，对小水管机器不友好。
4. 增加函数`reply_msg(ev, text)`，用来回复消息，同时修改了`chat.py`中的部分简单对话，来体现这一特性。

