### PR TITLE
用到normalize_text的无法获取到QQ小程序message进行on_rex/on_keyword

### DIFF
--- a/hoshino/service.py
+++ b/hoshino/service.py
@@ -269,9 +269,11 @@ class Service:
         return deco
 
 
-    def on_rex(self, rex: Union[str, re.Pattern], only_to_me=False, normalize=True) -> Callable:
+    def on_rex(self, rex: Union[str, re.Pattern], flags: Union[int, re.RegexFlag]=0, only_to_me=False, normalize=True) -> Callable:
+        if isinstance(flags, re.RegexFlag):
+            flags = flags.value
         if isinstance(rex, str):
-            rex = re.compile(rex)
+            rex = re.compile(rex, flags)
         def deco(func) -> Callable:
             sf = ServiceFunc(self, func, only_to_me, normalize)
             if isinstance(rex, re.Pattern):

--- a/hoshino/trigger.py
+++ b/hoshino/trigger.py
@@ -138,7 +138,7 @@ class RexTrigger(BaseTrigger):
 
 class _PlainTextExtractor(BaseTrigger):
     def find_handler(self, event: CQEvent):
-        event.plain_text = event.message.extract_plain_text().strip()
+        event.plain_text = str(event.message).strip()
         return []
 
 class _TextNormalizer(_PlainTextExtractor):


### PR DESCRIPTION
为on_rex添加标志位选择

修复所有用到normalize_text触发的服务无法获取到QQ小程序的message，小程序message的type好像不是text，aiocqhttp那边最后就返回了空