### PR TITLE
修复picfinder插件at搜图/回复搜图无法触发

### DIFF
--- a/hoshino/modules/picfinder/__init__.py
+++ b/hoshino/modules/picfinder/__init__.py
@@ -121,8 +121,9 @@ async def picmessage(bot, ev: CQEvent):
     atcheck = False
     batchcheck = False
     for m in ev.message:
-        if m.type == 'at' and m.data['qq']==ev.self_id:
+        if m.type == 'at' and str(m.data['qq']) == str(ev.self_id):
             atcheck = True
+            break
     if pls.get_on_off_status(ev.group_id):
         if int(pls.on[ev.group_id]) == int(ev.user_id):
             batchcheck = True
@@ -189,8 +190,9 @@ async def replymessage(bot, ev: CQEvent):
     is_at_me = 0
     flag2 = 0
     for m in ev.message[2:]:
-        if m.type == 'at' and m.data['qq'] == ev.self_id:
+        if m.type == 'at' and str(m.data['qq']) == str(ev.self_id):
             is_at_me = 1
+            break
     for name in NICKNAME:
         if name in cmd:
             is_at_me = 1


### PR DESCRIPTION
群友明明只搜一张图还要用批量搜图模式的原因找到了（
MessageSegment的`qq`字段是字符串，但是`ev.self_id`是数字，无法通过atcheck
也有可能是某次更新改了`qq`字段的类型？又考虑到`qq`字段还可能是all，干脆全转字符串比较