### PR TITLE
修复python新版本re弃用正则表达式内的内联标记的问题

### DIFF
--- a/hoshino/service.py
+++ b/hoshino/service.py
@@ -270,9 +270,9 @@ class Service:
         return deco
 
 
-    def on_rex(self, rex: Union[str, re.Pattern], only_to_me=False, normalize=True) -> Callable:
+    def on_rex(self, rex: Union[str, re.Pattern], only_to_me=False, normalize=True, inner_link: re.RegexFlag = None) -> Callable:
         if isinstance(rex, str):
-            rex = re.compile(rex)
+            rex = re.compile(rex) if inner_link is None else re.compile(rex, inner_link)
         def deco(func) -> Callable:
             sf = ServiceFunc(self, func, only_to_me, normalize)
             if isinstance(rex, re.Pattern):


### PR DESCRIPTION
新版本python不再支持正则表达式开头放置内联标记，如：`(?i)^scan$`
测试版本：3.11