### PR TITLE
修复官网结构变动导致台服新闻模块失效的问题

### DIFF
--- a/hoshino/modules/priconne/news/spider.py
+++ b/hoshino/modules/priconne/news/spider.py
@@ -55,7 +55,7 @@ class BaseSpider(abc.ABC):
 
 
 class SonetSpider(BaseSpider):
-    url = "http://www.princessconnect.so-net.tw/news/"
+    url = "https://www.princessconnect.so-net.tw/news/"
     src_name = "台服官网"
 
     @staticmethod

--- a/hoshino/modules/priconne/news/spider.py
+++ b/hoshino/modules/priconne/news/spider.py
@@ -62,9 +62,9 @@ class SonetSpider(BaseSpider):
     async def get_items(resp:aiorequests.AsyncResponse):
         soup = BeautifulSoup(await resp.text, 'lxml')
         return [
-            Item(idx=dd.a["href"],
-                 content=f"{dd.text}\n▲www.princessconnect.so-net.tw{dd.a['href']}"
-            ) for dd in soup.find_all("dd")
+            Item(idx=li.a["href"],
+                 content=f"{li.a.text}\n▲www.princessconnect.so-net.tw{li.a['href']}"
+            ) for li in soup.select("article.news_con ul>li")
         ]
 
 


### PR DESCRIPTION
台服的官网结构变化导致爬虫无法获取正确的节点
<img width="360" height="172" alt="image" src="https://github.com/user-attachments/assets/33f7ad1e-44b6-467c-a2fd-3eeaab58f898" />
<img width="1260" height="670" alt="787bf06068301ac9d8f73c35ae3e440c" src="https://github.com/user-attachments/assets/abc989df-bdd5-445c-86bf-032523881f59" />

另外pcr sonet官网好像开始使用https了, http网址好像有概率收到500
<img width="1254" height="274" alt="a79c46a2b637e1903c21a65e0a8803a1" src="https://github.com/user-attachments/assets/07cfeb10-6052-46ad-80b2-4a9e2ce3c605" />


PR中重新修改了爬虫的选择器, 并替换HTTPS的网址
<img width="1783" height="510" alt="ff764ccfe95a6e6479d7634f6d56ce04" src="https://github.com/user-attachments/assets/03d75558-ad7a-4dcb-b3ee-647ea076ab90" />
<img width="734" height="295" alt="image" src="https://github.com/user-attachments/assets/30c0cfc7-4ed5-481f-9ebc-3dcf3f2fb32a" />

